### PR TITLE
Prevent path traversal

### DIFF
--- a/lib/sensor/index.js
+++ b/lib/sensor/index.js
@@ -58,6 +58,10 @@ var getSensorDriver = function (model) {
   if (!model) {
     return;
   }
+  // Ensure that model is a single path component
+  if (model.includes(path.sep) || model === '..' || model === '.') {
+    throw new Error(`invalid ${model}`)
+  }
   if (_cachedDrivers[model]) {
     return _cachedDrivers[model];
   }


### PR DESCRIPTION
Ensure that `model` is a single path component. Otherwise, it is possible to read other files, e.g. by passing `../../var/log/xyz`.